### PR TITLE
[WIP] Basic mix reindex task and test helpers

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+elixir 1.11.2-otp-23
+erlang 23.3
+elasticsearch 7.10.0

--- a/lib/adapters/elastic_search.ex
+++ b/lib/adapters/elastic_search.ex
@@ -127,8 +127,9 @@ defmodule Spandex.Adapters.ElasticSearch do
     end
   end
 
-  defp index_name(%Spandex.Query{language: language} = query_struct) do
-    type_handler(query_struct)
+  defp index_name(%SearchService.Query{language: language, index: index})
+       when language in ["", "en"] do
+    index.type
     |> Macro.underscore()
     |> Inflex.pluralize()
     |> index_suffix(Mix.env())
@@ -145,11 +146,5 @@ defmodule Spandex.Adapters.ElasticSearch do
     Enum.map(languages, fn language ->
       function.(language)
     end)
-  end
-
-  defp type_handler(typed_struct) do
-    typed_struct.query.__struct__
-    |> Module.split()
-    |> List.last()
   end
 end

--- a/lib/mix/tasks/spandex/reindex.ex
+++ b/lib/mix/tasks/spandex/reindex.ex
@@ -1,0 +1,26 @@
+defmodule Mix.Tasks.Spandex.Reindex do
+  @moduledoc """
+  Does the spandex dance. For every index in the app this deletes
+  the old index, creates a new one and populates it
+  """
+  @shortdoc "Reindex all indices"
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_) do
+    Mix.Task.run("app.start")
+
+    actions = [:delete_index, :create_index, :update_index]
+
+    for {module, _} <- :code.all_loaded(),
+        Spandex.Behaviour.Index in (module.module_info(:attributes)
+                                    |> Keyword.get_values(:behaviour)
+                                    |> List.flatten()),
+        action <- actions do
+      module
+      |> Spandex.Query.compile(%{action: action})
+      |> Spandex.run_query()
+    end
+  end
+end

--- a/lib/query.ex
+++ b/lib/query.ex
@@ -1,10 +1,26 @@
 defmodule Spandex.Query do
   defstruct [:query, :index, :ecto_object, language: "en", action: :search]
 
-  def compile(query_map, params \\ %{}) when is_map(params) do
+  def compile(thing, params \\ %{})
+
+  def compile(query_map, params) when is_struct(query_map) and is_map(params) do
+    module =
+      query_map.__struct__
+      |> Module.split()
+      |> List.last()
+
+    index_module = Module.concat([Spandex, Index, module])
+
     struct(
       %Spandex.Query{},
-      Map.merge(params, %{query: query_map, index: query_map.index.reference()})
+      Map.merge(params, %{query: query_map, index: index_module.reference()})
+    )
+  end
+
+  def compile(index_module, params) when is_map(params) do
+    struct(
+      %Spandex.Query{},
+      Map.merge(params, %{query: %{}, index: index_module.reference()})
     )
   end
 end

--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -3,16 +3,17 @@ defmodule Spandex do
 
   def run_query(%{action: action} = query_map) do
     case apply(adapter(), action, [query_map]) do
-      {:ok,
-       %HTTPoison.Response{
-         status_code: status_code,
-         body: %{
-           "error" => %{
-             "index" => index,
-             "reason" => reason
-           }
-         }
-       }}
+      [
+        ok: %HTTPoison.Response{
+          status_code: status_code,
+          body: %{
+            "error" => %{
+              "index" => index,
+              "reason" => reason
+            }
+          }
+        }
+      ]
       when status_code != 200 ->
         {:error, index, reason}
 

--- a/lib/test/helpers.ex
+++ b/lib/test/helpers.ex
@@ -1,0 +1,21 @@
+defmodule Spandex.Test.Helpers do
+  def reindex_all() do
+    [:delete_index, :create_index, :update_index]
+    |> Enum.map(&take_action(&1))
+  end
+
+  def tear_down() do
+    take_action(:delete_index)
+  end
+
+  defp take_action(action) do
+    for {module, _} <- :code.all_loaded(),
+        Spandex.Behaviour.Index in (module.module_info(:attributes)
+                                    |> Keyword.get_values(:behaviour)
+                                    |> List.flatten()) do
+      module
+      |> Spandex.Query.compile(%{action: action})
+      |> Spandex.run_query()
+    end
+  end
+end


### PR DESCRIPTION
Adds in a mix task and test helpers that will reindex ES using all modules that implement the `Spandex.Behaviour.Index` Behaviour. To make this work a little better I made use of the index reference "type" field rather than implying the index name from the query struct.