### PR TITLE
Use github/ref for the elastix dep

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,8 +22,8 @@ defmodule Spandex.MixProject do
   defp deps do
     [
       {:elastix,
-       git: "git@github.com:Subatomic-Agency/elastix.git",
-       sha: "9afc57c9de3c3014d25b62d11e806433e72c35ba"},
+       github: "Subatomic-Agency/elastix",
+       ref: "9afc57c9de3c3014d25b62d11e806433e72c35ba"},
       {:inflex, "~> 2.1"}
     ]
   end


### PR DESCRIPTION
Small tweak to get spandex pulling and building from git during deploys. This doesn't appear to be well documented but here's the [allowed options](https://github.com/elixir-lang/elixir/blob/e6118608d668d307ccff2d6c1d90953c225d180d/lib/mix/lib/mix/scm/git.ex#L206-L212) for the `git`/ `github` options.